### PR TITLE
fixed a bug where the model generated with RGBA had a black background & add the option to remove the background

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,48 @@
-# ComfyUI-Flowty-TripoSR
+# ComfyUI-Flowty-TripoSR-ZHO
+
+## 我在原作者的基础上进行了修改，区别如下（已和原作者沟通，意见不同，所以作为独立分支）：
+
+1.是否内含背景去除功能
+- 原版：为了保证更快的生成速度，选择去掉了背景去除的步骤，仅保留了生成部分
+- 改版：增加了背景去除的选项，可以选择使用，也可选择不使用，速度上略慢一点
+
+2.对 RGBA 图像的支持不同
+- 目前原版 RGBA 图像直接转为 RGB 后生成的模型会带有黑色背板的，算是一个 bug，估计作者还会继续优化
+- 我的改版遵从原项目对 alpha 通道重新着色为灰色的操作，所以可以保证生成模型不会带有背景
+
+
+## 两版节点对比示意图：
+
+
+![TPSR](https://github.com/ZHO-ZHO-ZHO/ComfyUI-Flowty-TripoSR/assets/140084057/2feb13f8-3271-41cf-b2be-e937c4ba6209)
+
+
+## 与原版区别示意视频：
+
+
+
+https://github.com/ZHO-ZHO-ZHO/ComfyUI-Flowty-TripoSR/assets/140084057/f0e038c8-de7a-425c-ba02-0edc45617077
+
+
+
+## 使用建议：
+
+更加追求速度可直接选择原版，想要自带背景去除 + 更好的 RGBA 支持选择我的改版就好，两个版本之间没有好坏之分，大家根据自己的喜好选择就好！
+
+
+## 工作流设计：
+
+LayerDiffusion 和 TripoSR 简直绝配！所以设计了一版和 LayerDiffusion 衔接的工作流，由 LayerDiffusion 生成透明对象，然后直接通过 TripoSR 转为 3D 模型（用的是我这版节点）
+
+[LayerDIffusion + TripoSR 【Zho】](https://github.com/ZHO-ZHO-ZHO/ComfyUI-Flowty-TripoSR/blob/master/TRIPOSR-ZHO%20WORKFLOWS/LayerDIffusion%20%2B%20TripoSR%E3%80%90Zho%E3%80%91.json)
+
+
+![Dingtalk_20240305224540](https://github.com/ZHO-ZHO-ZHO/ComfyUI-Flowty-TripoSR/assets/140084057/fe05a7ef-6354-48e9-9b47-51207ac5814a)
+
+
+
+
+## 下面是原作者的内容：
 
 This is a custom node that lets you use TripoSR right from ComfyUI.
 

--- a/TRIPOSR-ZHO WORKFLOWS/LayerDIffusion + TripoSR【Zho】.json
+++ b/TRIPOSR-ZHO WORKFLOWS/LayerDIffusion + TripoSR【Zho】.json
@@ -1,0 +1,700 @@
+{
+  "last_node_id": 20,
+  "last_link_id": 39,
+  "nodes": [
+    {
+      "id": 5,
+      "type": "BRIA_RMBG_ModelLoader_Zho",
+      "pos": [
+        440,
+        660
+      ],
+      "size": {
+        "0": 360,
+        "1": 30
+      },
+      "flags": {},
+      "order": 0,
+      "mode": 2,
+      "outputs": [
+        {
+          "name": "rmbgmodel",
+          "type": "RMBGMODEL",
+          "links": [
+            4
+          ],
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "BRIA_RMBG_ModelLoader_Zho"
+      }
+    },
+    {
+      "id": 4,
+      "type": "BRIA_RMBG_Zho",
+      "pos": [
+        440,
+        740
+      ],
+      "size": {
+        "0": 360,
+        "1": 50
+      },
+      "flags": {},
+      "order": 4,
+      "mode": 2,
+      "inputs": [
+        {
+          "name": "rmbgmodel",
+          "type": "RMBGMODEL",
+          "link": 4,
+          "slot_index": 0
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 19,
+          "slot_index": 1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "links": [],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "mask",
+          "type": "MASK",
+          "links": null,
+          "shape": 3,
+          "slot_index": 1
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "BRIA_RMBG_Zho"
+      }
+    },
+    {
+      "id": 3,
+      "type": "LoadImage",
+      "pos": [
+        440,
+        840
+      ],
+      "size": {
+        "0": 360,
+        "1": 490
+      },
+      "flags": {},
+      "order": 1,
+      "mode": 2,
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            19
+          ],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "pasted/image.png",
+        "image"
+      ]
+    },
+    {
+      "id": 12,
+      "type": "CheckpointLoaderSimple",
+      "pos": [
+        -470,
+        2190
+      ],
+      "size": {
+        "0": 315,
+        "1": 98
+      },
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            27
+          ],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            29,
+            31
+          ],
+          "shape": 3,
+          "slot_index": 1
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            35
+          ],
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": [
+        "JuggernautXL.safetensors"
+      ]
+    },
+    {
+      "id": 13,
+      "type": "LayeredDiffusionApply",
+      "pos": [
+        -470,
+        2340
+      ],
+      "size": [
+        320,
+        80
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 27
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            28
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LayeredDiffusionApply"
+      },
+      "widgets_values": [
+        "Attention Injection",
+        1
+      ]
+    },
+    {
+      "id": 16,
+      "type": "EmptyLatentImage",
+      "pos": [
+        -470,
+        2470
+      ],
+      "size": {
+        "0": 315,
+        "1": 106
+      },
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            33
+          ],
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "EmptyLatentImage"
+      },
+      "widgets_values": [
+        1024,
+        1024,
+        1
+      ]
+    },
+    {
+      "id": 2,
+      "type": "TripoSRSampler",
+      "pos": [
+        -130,
+        2700
+      ],
+      "size": [
+        320,
+        140
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "reference_image",
+          "type": "IMAGE",
+          "link": 39,
+          "slot_index": 0
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MESH",
+          "type": "MESH",
+          "links": [
+            1
+          ],
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "TripoSRSampler"
+      },
+      "widgets_values": [
+        "TPSRmodel.ckpt",
+        8192,
+        false,
+        0.85
+      ]
+    },
+    {
+      "id": 19,
+      "type": "LayeredDiffusionDecodeRGBA",
+      "pos": [
+        -130,
+        2600
+      ],
+      "size": [
+        320,
+        50
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 36,
+          "slot_index": 0
+        },
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 37
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            38,
+            39
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LayeredDiffusionDecodeRGBA"
+      }
+    },
+    {
+      "id": 17,
+      "type": "VAEDecode",
+      "pos": [
+        -130,
+        2500
+      ],
+      "size": [
+        320,
+        50
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 34
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 35,
+          "slot_index": 1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            37
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode"
+      }
+    },
+    {
+      "id": 10,
+      "type": "KSampler",
+      "pos": [
+        -130,
+        2190
+      ],
+      "size": [
+        320,
+        260
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 28,
+          "slot_index": 0
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 30
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 32
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 33,
+          "slot_index": 3
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            34,
+            36
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        465119776497869,
+        "randomize",
+        20,
+        8,
+        "euler",
+        "normal",
+        1
+      ]
+    },
+    {
+      "id": 20,
+      "type": "PreviewImage",
+      "pos": [
+        210,
+        2190
+      ],
+      "size": [
+        680,
+        650
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 38
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "PreviewImage"
+      }
+    },
+    {
+      "id": 1,
+      "type": "TripoSRViewer",
+      "pos": [
+        -470,
+        2890
+      ],
+      "size": [
+        1360,
+        1260
+      ],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "mesh",
+          "type": "MESH",
+          "link": 1,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "TripoSRViewer"
+      },
+      "widgets_values": [
+        null
+      ]
+    },
+    {
+      "id": 15,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -470,
+        2760
+      ],
+      "size": [
+        320,
+        80
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 31
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            32
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        ""
+      ]
+    },
+    {
+      "id": 14,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -470,
+        2630
+      ],
+      "size": [
+        320,
+        80
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 29
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            30
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A toy bear"
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      2,
+      0,
+      1,
+      0,
+      "MESH"
+    ],
+    [
+      4,
+      5,
+      0,
+      4,
+      0,
+      "RMBGMODEL"
+    ],
+    [
+      19,
+      3,
+      0,
+      4,
+      1,
+      "IMAGE"
+    ],
+    [
+      27,
+      12,
+      0,
+      13,
+      0,
+      "MODEL"
+    ],
+    [
+      28,
+      13,
+      0,
+      10,
+      0,
+      "MODEL"
+    ],
+    [
+      29,
+      12,
+      1,
+      14,
+      0,
+      "CLIP"
+    ],
+    [
+      30,
+      14,
+      0,
+      10,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      31,
+      12,
+      1,
+      15,
+      0,
+      "CLIP"
+    ],
+    [
+      32,
+      15,
+      0,
+      10,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      33,
+      16,
+      0,
+      10,
+      3,
+      "LATENT"
+    ],
+    [
+      34,
+      10,
+      0,
+      17,
+      0,
+      "LATENT"
+    ],
+    [
+      35,
+      12,
+      2,
+      17,
+      1,
+      "VAE"
+    ],
+    [
+      36,
+      10,
+      0,
+      19,
+      0,
+      "LATENT"
+    ],
+    [
+      37,
+      17,
+      0,
+      19,
+      1,
+      "IMAGE"
+    ],
+    [
+      38,
+      19,
+      0,
+      20,
+      0,
+      "IMAGE"
+    ],
+    [
+      39,
+      19,
+      0,
+      2,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {},
+  "version": 0.4
+}

--- a/__init__.py
+++ b/__init__.py
@@ -8,6 +8,7 @@ from tsr.utils import remove_background, resize_foreground
 from PIL import Image
 import numpy as np
 import torch
+import rembg
 
 
 rembg_session = rembg.new_session()

--- a/__init__.py
+++ b/__init__.py
@@ -8,6 +8,14 @@ from PIL import Image
 import numpy as np
 import torch
 
+
+def fill_background(pli_image):
+    image = pli_image
+    image = image[:, :, :3] * image[:, :, 3:4] + (1 - image[:, :, 3:4]) * 0.5
+    image = Image.fromarray((image * 255.0).astype(np.uint8))
+    return image
+
+
 class TripoSRSampler:
 
     def __init__(self):
@@ -46,7 +54,10 @@ class TripoSRSampler:
 
         with torch.no_grad():
             for image in reference_image:
-                i = Image.fromarray(np.clip(255. * image.cpu().numpy().squeeze(), 0, 255).astype(np.uint8))
+                i = 255. * image.cpu().numpy()
+                i = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
+                if i.mode == 'RGBA':
+                    i = fill_background(i)
                 scene_codes = self.initialized_model([i], device)
                 meshes = self.initialized_model.extract_mesh(scene_codes)
                 outputs.append(meshes[0])

--- a/__init__.py
+++ b/__init__.py
@@ -48,6 +48,8 @@ class TripoSRSampler:
             for image in reference_image:
                 i = 255. * image.cpu().numpy()
                 i = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
+                if i.mode == 'RGBA':
+                    i = i.convert('RGB')
                 scene_codes = self.initialized_model([i], device)
                 meshes = self.initialized_model.extract_mesh(scene_codes)
                 outputs.append(meshes[0])

--- a/__init__.py
+++ b/__init__.py
@@ -46,10 +46,7 @@ class TripoSRSampler:
 
         with torch.no_grad():
             for image in reference_image:
-                i = 255. * image.cpu().numpy()
-                i = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
-                if i.mode == 'RGBA':
-                    i = i.convert('RGB')
+                i = Image.fromarray(np.clip(255. * image.cpu().numpy().squeeze(), 0, 255).astype(np.uint8))
                 scene_codes = self.initialized_model([i], device)
                 meshes = self.initialized_model.extract_mesh(scene_codes)
                 outputs.append(meshes[0])

--- a/__init__.py
+++ b/__init__.py
@@ -32,7 +32,7 @@ class TripoSRSampler:
                 "model": (get_filename_list("checkpoints"),),
                 "reference_image": ("IMAGE",),
                 "chunk_size": ("INT", {"default": 8192, "min": 1, "max": 10000}),
-                "remove_background": ("BOOLEAN", {"default": True}),
+                "do_remove_background": ("BOOLEAN", {"default": True}),
                 "foreground_ratio": ("FLOAT", {"default": 0.85, "min": 0, "max": 1.0, "step": 0.01}),
             }
         }
@@ -41,7 +41,7 @@ class TripoSRSampler:
     FUNCTION = "sample"
     CATEGORY = "Flowty TripoSR"
 
-    def sample(self, model, reference_image, chunk_size, remove_background, foreground_ratio):
+    def sample(self, model, reference_image, chunk_size, do_remove_background, foreground_ratio):
         outputs = []
 
         device = get_torch_device()
@@ -62,7 +62,7 @@ class TripoSRSampler:
             for image in reference_image:
                 i = 255. * image.cpu().numpy()
                 i = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
-                if remove_background:
+                if do_remove_background:
                     i = i.convert("RGB")
                     i = remove_background(i, rembg_session)
                     i = resize_foreground(i, foreground_ratio)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ transformers==4.35.0
 trimesh==4.0.5
 huggingface-hub
 imageio[ffmpeg]
+rembg

--- a/tsr/utils.py
+++ b/tsr/utils.py
@@ -7,13 +7,13 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import imageio
 import numpy as np
 import PIL.Image
-#import rembg
+import rembg
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import trimesh
 from omegaconf import DictConfig, OmegaConf
-#from PIL import Image
+from PIL import Image
 
 
 def parse_structured(fields: Any, cfg: Optional[Union[dict, DictConfig]] = None) -> Any:

--- a/tsr/utils.py
+++ b/tsr/utils.py
@@ -399,19 +399,19 @@ def get_spherical_cameras(
     return rays_o, rays_d
 
 
-# def remove_background(
-#     image: PIL.Image.Image,
-#     rembg_session: Any = None,
-#     force: bool = False,
-#     **rembg_kwargs,
-# ) -> PIL.Image.Image:
-#     do_remove = True
-#     if image.mode == "RGBA" and image.getextrema()[3][0] < 255:
-#         do_remove = False
-#     do_remove = do_remove or force
-#     if do_remove:
-#         image = rembg.remove(image, session=rembg_session, **rembg_kwargs)
-#     return image
+def remove_background(
+    image: PIL.Image.Image,
+    rembg_session: Any = None,
+    force: bool = False,
+    **rembg_kwargs,
+) -> PIL.Image.Image:
+    do_remove = True
+    if image.mode == "RGBA" and image.getextrema()[3][0] < 255:
+        do_remove = False
+    do_remove = do_remove or force
+    if do_remove:
+        image = rembg.remove(image, session=rembg_session, **rembg_kwargs)
+    return image
 
 
 def resize_foreground(


### PR DESCRIPTION
我修复了当前使用RGBA生成的模型带有黑色背景的bug，还增加了项目原本包含的背景去除选项，现在既可以使用自带的rembg去除背景，也支持直接使用RGBA或经过其他背景去除模型处理后的RGBA图像，这是我做的对比视频，第一段是原版，第二段是我的修复版

I fixed a bug where the model generated with RGBA had a black background. Additionally, I added the option to remove the background, which was originally included in the project. Now, you can either use the built-in rembg to remove the background or directly utilize RGBA images generated by the model after processing with other background removal methods. Here's a comparison video I made: the first segment is the original version, and the second segment is my fixed version.


https://github.com/flowtyone/ComfyUI-Flowty-TripoSR/assets/140084057/c4271dcc-4d9a-4cf0-bbd0-8347f3181607

